### PR TITLE
Change TypeNameHandling enum to be None

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
 
             _jsonSerializer = jsonSerializer ?? JsonSerializer.Create(new JsonSerializerSettings
                                                     {
-                                                        TypeNameHandling = TypeNameHandling.All,
+                                                        TypeNameHandling = TypeNameHandling.None,
                                                     });
 
             // Triggers a check for the existence of the container


### PR DESCRIPTION
Change TypeNameHandling enum to be None instead of All, because using All runs the risk of performing insecure Json.Net deserialization, especially since the Deserialization step (line 212) happens without using a custom SerializationBinder, and with content that is downloaded from potentially attacker-controlled content (an attacker's blob storage container).

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
I simply changed the TypeNameHandling to be None

